### PR TITLE
let job only be skipped by its own previous call.

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -76,9 +76,9 @@ func DelayIfStillRunning(logger Logger) JobWrapper {
 // SkipIfStillRunning skips an invocation of the Job if a previous invocation is
 // still running. It logs skips to the given logger at Info level.
 func SkipIfStillRunning(logger Logger) JobWrapper {
-	var ch = make(chan struct{}, 1)
-	ch <- struct{}{}
 	return func(j Job) Job {
+		var ch = make(chan struct{}, 1)
+		ch <- struct{}{}
 		return FuncJob(func() {
 			select {
 			case v := <-ch:


### PR DESCRIPTION
In the original code, the job will be skipped by other job, so modifying it into this job will only be skipped by its own previous call.